### PR TITLE
Update Formula-Cookbook.md

### DIFF
--- a/docs/Formula-Cookbook.md
+++ b/docs/Formula-Cookbook.md
@@ -100,7 +100,7 @@ Check the package’s `README`. Does the package install with `./configure`, `cm
 
 ### Check for dependencies
 
-The `README` probably tells you about dependencies and Homebrew or macOS probably already has them. You can check for Homebrew dependencies with `brew search`. Some common dependencies that macOS comes with:
+The `README` likely contains information about dependencies, and Homebrew or macOS may already have them installed. You can check for Homebrew dependencies with `brew search`. Some common dependencies that macOS comes with:
 
 * `libexpat`
 * `libGL`


### PR DESCRIPTION
After reading through the documentation for dependencies I found a portion of the documentation that could possibly be modified to enhance user understanding/prevent misunderstanding.

Changes Made to Check for Dependencies Section:

Original Verbiage: 
The `README` probably tells you about dependencies and Homebrew or macOS probably already has them.

Changed Verbiage:
The `README` likely contains information about dependencies, and Homebrew or macOS may already have them installed.

Reason For Changes: Improve user understanding

Thank you in advance.
